### PR TITLE
Sparoid: Specify OpenSSL as dependency (fix macOS)

### DIFF
--- a/Formula/sparoid.rb
+++ b/Formula/sparoid.rb
@@ -6,6 +6,7 @@ class Sparoid < Formula
   head "https://github.com/84codes/sparoid.git"
 
   depends_on "crystal" => :build
+  depends_on "openssl" => :build
 
   def install
     components = ["sparoid"]


### PR DESCRIPTION
Homebrews build environment will not automatically add casks in PATHs unless specified as dependencies.

https://docs.brew.sh/Formula-Cookbook#specifying-other-formulae-as-dependencies

Tested with: `brew reinstall ./Formula/sparoid.rb`