### PR TITLE
Update LavinMQ to 1.2.5, skip docs

### DIFF
--- a/Formula/lavinmq.rb
+++ b/Formula/lavinmq.rb
@@ -1,14 +1,15 @@
 class Lavinmq < Formula
   desc "Fast and efficient AMQP 0-9-1 server"
   homepage "https://www.lavinmq.com"
-  url "https://github.com/cloudamqp/lavinmq/archive/v1.0.0-beta.8.tar.gz"
-  sha256 "e0c7a90bc0b240f2dcf118a9c922c4b0ee604f19dfb2ed0b7137cb73af8abe3b"
+  url "https://github.com/cloudamqp/lavinmq/archive/v1.2.5.tar.gz"
+  sha256 "6529b81f1601840cb370d9cc54d70f422cf080bbe280c3a3738e276c0c6bd405"
   head "https://github.com/cloudamqp/lavinmq.git"
 
   depends_on "crystal" => :build
+  depends_on "openssl" => :build
 
   def install
-    system "make", "all"
+    system "make", "all", "DOCS="
     bin.install "bin/lavinmq"
     bin.install "bin/lavinmqctl"
     bin.install "bin/lavinmqperf"


### PR DESCRIPTION
Skipping docs since it requires npx, see discussion in https://github.com/cloudamqp/homebrew-cloudamqp/pull/10#issuecomment-1790275147 on better solutions.

I've tested this locally on my M2 Mac with `brew install Formula/lavinmq.rb` and seems to work.