### PR TITLE
Lavinmq service

### DIFF
--- a/Formula/lavinmq.rb
+++ b/Formula/lavinmq.rb
@@ -20,7 +20,7 @@ class Lavinmq < Formula
   end
 
   service do
-    run [opt_bin/"lavinmq", "-D", "/opt/homebrew/var/lavinmq"]
+    run [opt_bin/"lavinmq", "-D", var/"lavinmq"]
   end
 
   test do

--- a/Formula/lavinmq.rb
+++ b/Formula/lavinmq.rb
@@ -19,6 +19,10 @@ class Lavinmq < Formula
     bin.install "bin/lavinmqperf"
   end
 
+  service do
+    run [opt_bin / "lavinmq", "-D", "/opt/homebrew/var/lavinmq"]
+  end
+
   test do
     system "#{bin}/lavinmq", "--version"
     system "#{bin}/lavinmqctl", "--version"

--- a/Formula/lavinmq.rb
+++ b/Formula/lavinmq.rb
@@ -20,7 +20,7 @@ class Lavinmq < Formula
   end
 
   service do
-    run [opt_bin / "lavinmq", "-D", "/opt/homebrew/var/lavinmq"]
+    run [opt_bin/"lavinmq", "-D", "/opt/homebrew/var/lavinmq"]
   end
 
   test do


### PR DESCRIPTION
Let LavinMQ be run with brew services, by adding a service block according to[ Homebrew docs](https://docs.brew.sh/Formula-Cookbook#service-files)

Also updates the version of LavinMQ 