### PR TITLE
Fix: build lavinmqctl separately

### DIFF
--- a/Formula/lavinmq.rb
+++ b/Formula/lavinmq.rb
@@ -14,7 +14,8 @@ class Lavinmq < Formula
 
   def install
     system "make", "bin/lavinmq", "bin/lavinmqperf", "DOCS="
-    system "crystal", "build", "src/lavinmqctl.cr", "-o", "bin/lavinmqctl", "--release", "--error-on-warnings", "--link-flags=-pie"
+    system "crystal", "build", "src/lavinmqctl.cr", "-o", "bin/lavinmqctl", "--release", "--error-on-warnings",
+      "--link-flags=-pie"
     bin.install "bin/lavinmq"
     bin.install "bin/lavinmqctl"
     bin.install "bin/lavinmqperf"

--- a/Formula/lavinmq.rb
+++ b/Formula/lavinmq.rb
@@ -13,7 +13,8 @@ class Lavinmq < Formula
   depends_on "pcre2"
 
   def install
-    system "make", "all", "DOCS="
+    system "make", "bin/lavinmq", "bin/lavinmqperf", "DOCS="
+    system "crystal", "build", "src/lavinmqctl.cr", "-o", "bin/lavinmqctl", "--release", "--error-on-warnings", "--link-flags=-pie"
     bin.install "bin/lavinmq"
     bin.install "bin/lavinmqctl"
     bin.install "bin/lavinmqperf"


### PR DESCRIPTION
This is a workaround for a [bug in crystal](https://github.com/crystal-lang/crystal/pull/15144)