### PR TITLE
lavinmq: bump to 2.7.0

### DIFF
--- a/Formula/lavinmq.rb
+++ b/Formula/lavinmq.rb
@@ -1,8 +1,8 @@
 class Lavinmq < Formula
   desc "Message broker implementing the AMQP 0-9-1 and MQTT protocols"
   homepage "https://lavinmq.com"
-  url "https://github.com/cloudamqp/lavinmq/archive/refs/tags/v2.6.10.tar.gz"
-  sha256 "6799415d293834aa373e8098d2ac015d4b0f1412799f5c37989581ca6c09bcc6"
+  url "https://github.com/cloudamqp/lavinmq/archive/refs/tags/v2.7.0.tar.gz"
+  sha256 "8aace1e2c93d1d180f85cf1573170d8f057aa85db91106de22286ff4e61524b4"
   license "Apache-2.0"
   head "https://github.com/cloudamqp/lavinmq.git", branch: "main"
 


### PR DESCRIPTION
https://github.com/cloudamqp/lavinmq/releases/tag/v2.7.0