### PR TITLE
lavinm: CI Adaptive sleep to wait on LavinMQ starting

### DIFF
--- a/Formula/lavinmq.rb
+++ b/Formula/lavinmq.rb
@@ -49,7 +49,12 @@ class Lavinmq < Formula
     pid = fork do
       exec bin/"lavinmq", "--data-dir", testpath/"data"
     end
-    sleep 3
+    Timeout.timeout(30) do
+      shell_output("#{bin}/lavinmqctl status")
+    rescue RuntimeError
+      sleep 1
+      retry
+    end
     output = shell_output("#{bin}/lavinmqctl status")
     assert_match "Uptime", output
   ensure


### PR DESCRIPTION
Getting timeout on homebrew-core macOS 14-x86_64.