### PR TITLE
new version of cloudamqp-cli

### DIFF
--- a/Formula/cloudamqp-cli.rb
+++ b/Formula/cloudamqp-cli.rb
@@ -1,8 +1,8 @@
 class CloudamqpCli < Formula
   desc "CLI tool for managing CloudAMQP instances"
   homepage "https://github.com/cloudamqp/cli"
-  url "https://github.com/cloudamqp/cli/archive/refs/tags/v0.2.0.tar.gz"
-  sha256 "1464d530d0ade8d63e77961cd63832d4e7f2cff9d9361a9a7b853bb9189f1b6f"
+  url "https://github.com/cloudamqp/cli/archive/refs/tags/v0.3.0.tar.gz"
+  sha256 "c10a907c47d5d07d8c7c27c6aef1ecdd41f487e76a25ee87ab329893fc2a6fcf"
   license "MIT"
 
   depends_on "go" => :build


### PR DESCRIPTION
we should make the new version of cloudamqp-cli available through brew.