### PR TITLE
lavinmq: Use `make install`

### DIFF
--- a/Formula/lavinmq.rb
+++ b/Formula/lavinmq.rb
@@ -6,6 +6,7 @@ class Lavinmq < Formula
   license "Apache-2.0"
   head "https://github.com/cloudamqp/lavinmq.git", branch: "main"
 
+  depends_on "coreutils" => :build # GNU install (Makefile uses `install -D -t`)
   depends_on "crystal" => :build
   depends_on "help2man" => :build
   depends_on "bdw-gc"
@@ -19,16 +20,15 @@ class Lavinmq < Formula
   end
 
   def install
-    system "make", "bin/lavinmq", "bin/lavinmqctl", "bin/lavinmqperf", "DOCS="
-    system "make", "man"
+    ENV.prepend_path "PATH", Formula["coreutils"].opt_libexec/"gnubin"
 
-    bin.install "bin/lavinmq"
-    bin.install "bin/lavinmqctl"
-    bin.install "bin/lavinmqperf"
-
-    man1.install "man1/lavinmq.1"
-    man1.install "man1/lavinmqctl.1"
-    man1.install "man1/lavinmqperf.1"
+    system "make", "install",
+           "DOCS=",
+           "PREFIX=#{prefix}",
+           "SYSCONFDIR=#{buildpath}/stage/etc",
+           "UNITDIR=#{buildpath}/stage/systemd",
+           "SYSUSERSDIR=#{buildpath}/stage/sysusers",
+           "SHAREDSTATEDIR=#{buildpath}/stage/var"
 
     unless (pkgetc/"lavinmq.ini").exist?
       pkgetc.install "extras/lavinmq.ini"

--- a/Formula/lavinmq.rb
+++ b/Formula/lavinmq.rb
@@ -6,7 +6,6 @@ class Lavinmq < Formula
   license "Apache-2.0"
   head "https://github.com/cloudamqp/lavinmq.git", branch: "main"
 
-  depends_on "coreutils" => :build # GNU install (Makefile uses `install -D -t`)
   depends_on "crystal" => :build
   depends_on "help2man" => :build
   depends_on "bdw-gc"
@@ -14,13 +13,18 @@ class Lavinmq < Formula
   depends_on "openssl@3"
   depends_on "pcre2"
 
+  on_macos do
+    # GNU install (Makefile uses `install -D -t`); Linux's /usr/bin/install is already GNU.
+    depends_on "coreutils" => :build
+  end
+
   on_linux do
     depends_on "pkgconf" => :build
     depends_on "zlib-ng-compat"
   end
 
   def install
-    ENV.prepend_path "PATH", Formula["coreutils"].opt_libexec/"gnubin"
+    ENV.prepend_path "PATH", Formula["coreutils"].opt_libexec/"gnubin" if OS.mac?
 
     system "make", "install",
            "DOCS=",


### PR DESCRIPTION
Instead specific installing each binary/manual just rely on `make install`, will make it easier to handle updates if we get more binaries etc.

Replace manual bin/man install steps with the Makefile's `install` target, staging directories that Homebrew doesn't need (etc, systemd, sysusers, var) into buildpath. Requires GNU `install` (for `-D -t`), so depend on `coreutils` at build time and mutate the PATH to make it chose the correct `install`.

Will probably look into this in LavinMQ; but this is a "blocker" for getting LavinMQ into homebrew core.