### PR TITLE
lavinmq: Poll for control socket in test

### DIFF
--- a/Formula/lavinmq.rb
+++ b/Formula/lavinmq.rb
@@ -49,7 +49,11 @@ class Lavinmq < Formula
     pid = fork do
       exec bin/"lavinmq", "--data-dir", testpath/"data"
     end
-    sleep 3
+    30.times do
+      break if File.exist?("/tmp/lavinmqctl.sock")
+
+      sleep 1
+    end
     output = shell_output("#{bin}/lavinmqctl status")
     assert_match "Uptime", output
   ensure


### PR DESCRIPTION
Replace the fixed 3-second sleep with a loop that waits up to 30 seconds for `/tmp/lavinmqctl.sock` to appear, so the test is less flaky on slower builders while still failing fast once the server is ready.