### PR TITLE
lavinmq: drop post_install

### DIFF
--- a/Formula/lavinmq.rb
+++ b/Formula/lavinmq.rb
@@ -40,10 +40,6 @@ class Lavinmq < Formula
     end
   end
 
-  def post_install
-    (var/"lavinmq").mkpath
-  end
-
   service do
     run [opt_bin/"lavinmq", "-c", etc/"lavinmq/lavinmq.ini"]
     keep_alive true


### PR DESCRIPTION
lavinmq creates data_dir on startup, so pre-creating var/lavinmq is redundant.