### PR TITLE
CI: add automated formula bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -28,7 +28,7 @@ jobs:
           if [ -n "$input" ]; then
             formulas=$(printf '%s\n' "$input" | jq -Rcn '[inputs | split(" ")[] | select(length > 0)]')
           else
-            formulas=$(ls Formula/*.rb | xargs -n1 basename | sed 's/\.rb$//' | jq -Rcn '[inputs]')
+            formulas=$(for f in Formula/*.rb; do basename "$f" .rb; done | jq -Rcn '[inputs]')
           fi
           echo "formulas=$formulas" >> "$GITHUB_OUTPUT"
           echo "Discovered: $formulas"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -14,35 +14,51 @@ permissions:
   pull-requests: write
 
 jobs:
-  bump:
+  discover:
     runs-on: ubuntu-latest
+    outputs:
+      formulas: ${{ steps.list.outputs.formulas }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: List formulas
+        id: list
+        run: |
+          set -eu
+          input="${{ inputs.formula }}"
+          if [ -n "$input" ]; then
+            formulas=$(printf '%s\n' "$input" | jq -Rcn '[inputs | split(" ")[] | select(length > 0)]')
+          else
+            formulas=$(ls Formula/*.rb | xargs -n1 basename | sed 's/\.rb$//' | jq -Rcn '[inputs]')
+          fi
+          echo "formulas=$formulas" >> "$GITHUB_OUTPUT"
+          echo "Discovered: $formulas"
+
+  bump:
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        formula: ${{ fromJSON(needs.discover.outputs.formulas) }}
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
-      - name: Bump formulas
+      - name: Bump ${{ matrix.formula }}
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -u
-          formulas="${{ inputs.formula }}"
-          if [ -z "$formulas" ]; then
-            formulas="sparoid amqpcat cloudamqp-cli"
+          output=$(brew bump --open-pr --no-fork --no-browse \
+            "cloudamqp/cloudamqp/${{ matrix.formula }}" 2>&1) || true
+          echo "$output"
+          pr_url=$(printf '%s\n' "$output" \
+            | grep -oE 'https://github\.com/[^[:space:]]+/pull/[0-9]+' \
+            | tail -n1)
+          if [ -n "$pr_url" ]; then
+            pr_num=${pr_url##*/}
+            branch=$(gh pr view "$pr_num" --json headRefName --jq .headRefName)
+            echo "Triggering CI for PR #${pr_num} on branch ${branch}"
+            gh workflow run main.yml --ref "$branch"
           fi
-          for f in $formulas; do
-            echo "::group::$f"
-            output=$(brew bump --open-pr --no-fork --no-browse \
-              "cloudamqp/cloudamqp/$f" 2>&1) || true
-            echo "$output"
-            pr_url=$(printf '%s\n' "$output" \
-              | grep -oE 'https://github\.com/[^[:space:]]+/pull/[0-9]+' \
-              | tail -n1)
-            if [ -n "$pr_url" ]; then
-              pr_num=${pr_url##*/}
-              branch=$(gh pr view "$pr_num" --json headRefName --jq .headRefName)
-              echo "Triggering CI for PR #${pr_num} on branch ${branch}"
-              gh workflow run main.yml --ref "$branch"
-            fi
-            echo "::endgroup::"
-          done

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,48 @@
+name: Bump formulas
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      formula:
+        description: "Formula to bump (leave blank for all)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Bump formulas
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -u
+          formulas="${{ inputs.formula }}"
+          if [ -z "$formulas" ]; then
+            formulas="sparoid amqpcat cloudamqp-cli"
+          fi
+          for f in $formulas; do
+            echo "::group::$f"
+            output=$(brew bump --open-pr --no-fork --no-browse \
+              "cloudamqp/cloudamqp/$f" 2>&1) || true
+            echo "$output"
+            pr_url=$(printf '%s\n' "$output" \
+              | grep -oE 'https://github\.com/[^[:space:]]+/pull/[0-9]+' \
+              | tail -n1)
+            if [ -n "$pr_url" ]; then
+              pr_num=${pr_url##*/}
+              branch=$(gh pr view "$pr_num" --json headRefName --jq .headRefName)
+              echo "Triggering CI for PR #${pr_num} on branch ${branch}"
+              gh workflow run main.yml --ref "$branch"
+            fi
+            echo "::endgroup::"
+          done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: main
   pull_request:
+  workflow_dispatch:
 jobs:
   test-bot:
     runs-on: ${{ matrix.os }}
@@ -41,5 +42,5 @@ jobs:
             echo "::error::brew test-bot failed"
             exit 1
           fi
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
         shell: bash

--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ Three channels are available, install only one:
 
 ## Updating formulas
 
-To bump a formula to a new version:
+A daily GitHub Actions workflow (`.github/workflows/bump.yml`) runs `brew bump`
+against each formula and opens a PR when an upstream release is detected via
+`brew livecheck`. It can also be triggered manually from the Actions tab, and
+optionally limited to a single formula.
+
+To bump a formula manually:
 
 ```shell
 brew bump-formula-pr --no-fork --version=<version> <formula>


### PR DESCRIPTION
Runs daily via cron (and on demand) to detect new upstream releases via `brew livecheck` and open bump PRs. 

Triggers the existing test-bot workflow on each bump branch via workflow_dispatch so the default GITHUB_TOKEN is sufficient. I wanted to avoid creating another PAT/GitHub app right now.