### PR TITLE
CI: fix bump workflow — drop invalid `--no-browse` flag

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -49,13 +49,17 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -u
-          output=$(brew bump --open-pr --no-fork --no-browse \
-            "cloudamqp/cloudamqp/${{ matrix.formula }}" 2>&1) || true
+          set -eu
+          output=$(brew bump --open-pr --no-fork \
+            "cloudamqp/cloudamqp/${{ matrix.formula }}" 2>&1)
           echo "$output"
+          # brew bump prints the new PR URL on a line of its own (see
+          # bump-formula-pr.rb's `puts url` branch). Anchoring on ^...$
+          # ensures we don't pick up URLs from "Duplicate pull requests:"
+          # or "Maybe duplicate pull requests:" lines.
           pr_url=$(printf '%s\n' "$output" \
-            | grep -oE 'https://github\.com/[^[:space:]]+/pull/[0-9]+' \
-            | tail -n1)
+            | grep -E '^https://github\.com/[^[:space:]]+/pull/[0-9]+$' \
+            | tail -n1 || true)
           if [ -n "$pr_url" ]; then
             pr_num=${pr_url##*/}
             branch=$(gh pr view "$pr_num" --json headRefName --jq .headRefName)


### PR DESCRIPTION
## Summary

The bump workflow added in #52 silently failed on every formula in https://github.com/cloudamqp/homebrew-cloudamqp/actions/runs/25716464818:

```
##[error]invalid option: --no-browse
```

`brew bump` does not accept `--no-browse` — that flag belongs to `brew bump-formula-pr`. `brew bump --open-pr` already appends `--no-browse` internally when invoking `bump-formula-pr` (see `dev-cmd/bump.rb`), so the flag was both wrong and redundant. The failure was masked by `|| true`, leaving jobs green with only an annotation.

## Changes

- Drop `--no-browse` from the `brew bump` invocation.
- Switch to `set -eu` and remove `|| true` so real errors fail the job loudly.
- Anchor the PR-URL grep with `^...$`. `bump-formula-pr.rb` prints the new PR URL on its own line; without anchors we'd also match URLs inside "Duplicate pull requests:" / "Maybe duplicate pull requests:" lines and end up triggering CI on the wrong (old) PR.

## Local verification

- `brew bump --help` confirms `--open-pr` and `--no-fork` are valid; `--no-browse` is not listed.
- `dev-cmd/bump.rb:732` shows `brew bump --open-pr` passes `--no-browse` to `bump-formula-pr` itself.
- Ran `brew bump cloudamqp/cloudamqp/{cloudamqp-cli,sparoid,lavinmq-prerelease,amqpcat}` locally — completes cleanly, reports versions and duplicate-PR state as expected.
- Tested the tightened grep against fixtures of both "new PR opened" and "duplicate PR exists" output; only the standalone URL is captured.

The `--open-pr` path itself was not exercised locally to avoid opening real PRs against the tap.