### PR TITLE
CI: always print brew bump output even on failure

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -49,10 +49,17 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -eu
+          set -u
+          # Capture status separately so we always print brew's output;
+          # `bash -e {0}` otherwise exits on the failed assignment before
+          # the echo runs and the diagnostic is lost.
+          status=0
           output=$(brew bump --open-pr --no-fork \
-            "cloudamqp/cloudamqp/${{ matrix.formula }}" 2>&1)
+            "cloudamqp/cloudamqp/${{ matrix.formula }}" 2>&1) || status=$?
           echo "$output"
+          if [ "$status" -ne 0 ]; then
+            exit "$status"
+          fi
           # brew bump prints the new PR URL on a line of its own (see
           # bump-formula-pr.rb's `puts url` branch). Anchoring on ^...$
           # ensures we don't pick up URLs from "Duplicate pull requests:"


### PR DESCRIPTION
## Summary

The sparoid dispatch in https://github.com/cloudamqp/homebrew-cloudamqp/actions/runs/25716983994 failed silently — exit code 1 with zero diagnostic output. `bash -e {0}` aborts on a failed command substitution assignment, so when `brew bump` exited non-zero the `echo "$output"` below it never ran.

Capture the exit status with `|| status=$?` so we always print the output first, then exit with brew's status. This will let us actually see why sparoid fails.

## Test plan

- [ ] After merge, dispatch `Bump formulas` with `formula: sparoid` — expect the job to still fail, but with the real brew bump output visible in the log so the next fix has something to bite on.