### PR TITLE
CI: tap homebrew/core in bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -43,6 +43,11 @@ jobs:
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@main
+        with:
+          # `brew bump --open-pr` invokes `bump-formula-pr`, which runs
+          # `brew audit` and needs homebrew/core tapped to resolve deps
+          # like crystal/openssl@3/pcre2/etc.
+          core: true
 
       - name: Bump ${{ matrix.formula }}
         env:


### PR DESCRIPTION
## Summary

With output capture fixed (#54), run https://github.com/cloudamqp/homebrew-cloudamqp/actions/runs/25717096560 surfaced the real failure for sparoid:

```
cloudamqp/cloudamqp/sparoid
  * Can't find dependency 'crystal'.
  * Can't find dependency 'bdw-gc'.
  * Can't find dependency 'openssl@3'.
  * Can't find dependency 'pcre2'.
  * Can't find dependency 'nftables'.
  * Can't find dependency 'zlib-ng-compat'.
##[error]`brew audit` failed for sparoid!
```

`brew bump --open-pr` calls `bump-formula-pr` internally, which always runs `brew audit`. Audit needs homebrew/core tapped to resolve the formula's deps. `Homebrew/actions/setup-homebrew` does not tap it by default — has to be opted in via the `core` input.

## Test plan

- [ ] Dispatch with `formula: sparoid` — expect audit to pass and a real PR to be opened for 2.0.0 → 2.0.2.
- [ ] Confirm `main.yml` is then triggered on the new bump branch.