### PR TITLE
CI: set git author identity for bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -53,6 +53,11 @@ jobs:
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # `brew bump-formula-pr` only sets git author/committer from
+          # these env vars (utils/git.rb `set_name_email!`). Without them
+          # the runner has no git identity and `git commit` exits 128.
+          HOMEBREW_GIT_NAME: github-actions[bot]
+          HOMEBREW_GIT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
         run: |
           set -u
           # Capture status separately so we always print brew's output;


### PR DESCRIPTION
`brew bump --open-pr` invokes bump-formula-pr which calls Utils::Git.set_name_email! before `git commit`. That helper only sources the identity from $HOMEBREW_GIT_NAME / $HOMEBREW_GIT_EMAIL — without them the runner has no git identity and the commit fails with exit 128 ("empty ident name … not allowed"), as seen in run 26938494351.

Use the github-actions[bot] noreply address so the resulting PR is attributed to the bot.