### PR TITLE
CI: fix brew test-bot workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,10 @@ on:
     branches: main
   pull_request:
   workflow_dispatch:
+env:
+  # GHA runners are ephemeral VMs; Homebrew's Linux sandbox would just
+  # add a bubblewrap install step with no security benefit here.
+  HOMEBREW_NO_SANDBOX_LINUX: 1
 jobs:
   test-bot:
     runs-on: ${{ matrix.os }}
@@ -19,10 +23,10 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}


### PR DESCRIPTION
Three issues caused PRs to fail before any formula was built:

- Homebrew/actions/setup-homebrew@master is deprecated and will become an error in Homebrew 5.2.0; switch to @main per upstream README.
- actions/cache@v4 runs on Node.js 20 (deprecated); v5 runs on Node 24.
- `brew doctor` (invoked by --only-setup) fails on Linux when the sandbox is enabled but bwrap is missing. GHA runners are ephemeral VMs, so the sandbox adds no security benefit here — disable it via HOMEBREW_NO_SANDBOX_LINUX rather than installing bubblewrap.